### PR TITLE
Added spawner changes, and Arenas directory with basic Lust wave

### DIFF
--- a/Pixhell/Assets/Scenes/Global.unity
+++ b/Pixhell/Assets/Scenes/Global.unity
@@ -158,6 +158,7 @@ Transform:
   - {fileID: 1041608795}
   - {fileID: 600269227}
   - {fileID: 1950777087}
+  - {fileID: 769964851}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &108339562
@@ -2544,6 +2545,55 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 711799841}
   m_CullTransparentMesh: 1
+--- !u!1 &769964850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 769964851}
+  - component: {fileID: 769964852}
+  m_Layer: 0
+  m_Name: WaveController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &769964851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769964850}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 108339561}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &769964852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 769964850}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8403351b54fef2a4cb2c4f96b8dfe87c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minSpawnDistance: 7
+  tempTestPrefab: {fileID: 5085792645026659305, guid: 980b5b7fcd5c07e43b8d83622e64fdd8, type: 3}
+  spawning: 0
+  currentWave: 0
+  scriptCompleted: 0
 --- !u!1 &789887827
 GameObject:
   m_ObjectHideFlags: 0

--- a/Pixhell/Assets/Scripts/Combat/Spawners/Spawner.cs
+++ b/Pixhell/Assets/Scripts/Combat/Spawners/Spawner.cs
@@ -1,22 +1,134 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using System;
+using System.Collections;
+using System.IO;
+using System.Collections.Generic;
 
 public class Spawner : MonoBehaviour
 {
-    public GameObject spawnEnemy;
-    
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        Instantiate(spawnEnemy, transform.position, transform.rotation);
+
+    public float minSpawnDistance = 7f;
+    public GameObject tempTestPrefab;
+    GameObject player;
+    string sceneName;
+    string waveDataFilePath;
+    public bool spawning;
+    int spawnersRunning;
+    public int currentWave;
+    public bool scriptCompleted;
+
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode) {
+        StopAllCoroutines();
+        spawning = false;
+        scriptCompleted = false;
+        spawnersRunning = 0;
+        player = GameObject.FindWithTag("Player");
+        sceneName = scene.name;
+        waveDataFilePath = Path.Combine(Application.streamingAssetsPath, "Arenas", sceneName + ".csv");
+        Debug.Log("Checking for enemies.");
+        if (File.Exists(waveDataFilePath)) {
+            spawning = true;
+            currentWave = 1;
+            StartCoroutine(RunSpawnScript());
+            StartCoroutine(ArenaCompleted());
+        }
     }
 
-    // Update is called once per frame
-    void Update()
+    IEnumerator ArenaCompleted()
     {
-        var target = GameObject.FindWithTag("Enemy");
-        
-        if (!target) {
-            Instantiate(spawnEnemy, transform.position, transform.rotation);
+        while (!scriptCompleted)
+        {
+            yield return null;
         }
+        SceneManager.LoadScene("Limbo");
+    }
+
+    IEnumerator RunSpawnScript() {
+        string[] lines = File.ReadAllLines(waveDataFilePath);
+        while (spawning) {
+            string[] waveLines = GetWaveLines(lines);
+            if (waveLines.Length == 0) { break; }
+                
+            foreach (string line in waveLines) {
+                StartCoroutine(SpawnLine(line));
+            }
+            yield return new WaitUntil(IsNoEnemies);
+            Debug.Log(currentWave);
+            currentWave++;
+        }
+        scriptCompleted = true;
+    }
+
+    bool IsNoEnemies()
+    {
+        if (spawnersRunning > 0) {
+            return false;
+        }
+        Scene targetScene = SceneManager.GetSceneByName(sceneName);
+        GameObject[] rootObjects = targetScene.GetRootGameObjects();
+        foreach (var rootObj in rootObjects)
+        {
+            Debug.Log(rootObj.name);
+            if (rootObj.CompareTag("Enemy"))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    IEnumerator SpawnLine(string line) {
+        spawnersRunning += 1;
+        string[] parts = line.Split(',');
+        string enemyType = parts[1];
+        int count = int.Parse(parts[2]);
+        float timeToSpawn = float.Parse(parts[3]);
+        float delay = float.Parse(parts[4]);
+        yield return new WaitForSeconds(delay);
+        for (int i = 0; i < count; i++) {
+            SpawnEnemy(enemyType);
+            yield return new WaitForSeconds(timeToSpawn / count);
+        }
+        spawnersRunning -= 1;
+    }
+
+    void SpawnEnemy(string enemyType) {
+        //GameObject enemyPrefab = Resources.Load<GameObject>("Enemies/" + enemyType);
+        GameObject enemyPrefab = tempTestPrefab;
+        if (enemyPrefab != null) {
+            Instantiate(enemyPrefab, GetRandomSpawnPosition(), Quaternion.identity);
+        } else {
+            Debug.LogError("Enemy prefab not found: " + enemyType);
+        }
+    }
+
+    Vector3 GetRandomSpawnPosition() 
+    {
+        float xMod = 0f;
+        float yMod = 0f;
+        while (Mathf.Sqrt(xMod * xMod + yMod * yMod) < 0.2f)
+        {
+            xMod = (UnityEngine.Random.value - 0.5f) * 2f;
+            yMod = (UnityEngine.Random.value - 0.5f) * 2f;
+        }
+        
+        return player.transform.position + new Vector3(xMod * minSpawnDistance, yMod * minSpawnDistance, 0);
+    }
+
+    string[] GetWaveLines(string[] allLines) {
+        List<string> filteredLines = new List<string>();
+        foreach (var line in allLines)
+        {
+            if (line.StartsWith(currentWave.ToString() + ","))
+            {
+                filteredLines.Add(line);
+            }
+        }
+        return filteredLines.ToArray();
+    }
+
+    void Start() {
+        SceneManager.sceneLoaded += OnSceneLoaded;
     }
 }

--- a/Pixhell/Assets/StreamingAssets/Arenas.meta
+++ b/Pixhell/Assets/StreamingAssets/Arenas.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4ac68f31749cc224683a803f48800174
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Pixhell/Assets/StreamingAssets/Arenas/Lust.csv
+++ b/Pixhell/Assets/StreamingAssets/Arenas/Lust.csv
@@ -1,0 +1,4 @@
+wave,enemy,count,time_to_spawn,delay_after_start_of_wave
+1,archer,10,5,3
+1,archer,1,1,10
+2,archer,5,0.1,1

--- a/Pixhell/Assets/StreamingAssets/Arenas/Lust.csv.meta
+++ b/Pixhell/Assets/StreamingAssets/Arenas/Lust.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3204868dae5cc3247b88ab2b43204047
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Updated the spawner controller so that it is much more customizable and allows for customizable waves and enemy counts, which can be controlled in the Assets/StreamingAssets/Arenas/<arena>.csv. To add more arena scripts, ensure the names of future files match the scene that they will work with.

The spawn positions in Lust have been removed, and instead replaced by a global script that bases enemy spawn positions off of the current player position (semi-randomly). This is easily customizable, but for now has a basic implementation.