### PR TITLE
Fixed Attached Issue (Leveling Up After Death)

### DIFF
--- a/Pixhell/Assets/Scripts/Character/CharacterControl.cs
+++ b/Pixhell/Assets/Scripts/Character/CharacterControl.cs
@@ -299,6 +299,10 @@ public class PlayerController : MonoBehaviour
         damage_mult += increase;
     }
 
+    public bool IsDead() {
+        return is_dead;
+    }
+
     // Basic attacks for players
     protected virtual void BasicAttack(Vector2 move)
     {

--- a/Pixhell/Assets/Scripts/Upgrades/LevelUp.cs
+++ b/Pixhell/Assets/Scripts/Upgrades/LevelUp.cs
@@ -18,8 +18,8 @@ public class LevelUp : MonoBehaviour
 
     // Update is called once per frame
     void Update()
-    {
-        if (experience >= levelCaps[Mathf.Min(level, levelCaps.Length-1)]) {
+    {   
+        if (experience >= levelCaps[Mathf.Min(level, levelCaps.Length-1)] && !gameObject.GetComponent<PlayerController>().IsDead()) {
             experience -= levelCaps[level];
             level++;
 

--- a/Pixhell/Assets/Scripts/Upgrades/XPOrb.cs
+++ b/Pixhell/Assets/Scripts/Upgrades/XPOrb.cs
@@ -34,7 +34,8 @@ public class XPOrb : MonoBehaviour
     {
         // Collision Damage
         var target = other.GetComponent<LevelUp>(); 
-        if (target != null)
+        var playerComponent = other.GetComponent<PlayerController>();
+        if (target != null && !playerComponent.IsDead())
         {
             target.experience += XPAmount;
             Destroy(gameObject);


### PR DESCRIPTION
Fix: 
Added public function to player to check if the player is dead for future use
Disabled XP orb collision when dead
Added an additional layer: Upgrade UI is disabled (i.e. will not open) when dead. 

Testing:
Enter an arena, and get one away from leveling up
Get an additional XP Orb on the ground, and get one hit away from death. 
Ensure that the XP orb is moving towards you when you are about to die, but not close enough it reaches you before you die. 
Ensure the XP orb does not get destroyed and added to your XP, and the upgrade UI does not show up.