### PR TITLE
Patched Wave Spawner to Include Fence Post Problem

### DIFF
--- a/Pixhell/Assets/Scripts/Combat/Spawners/Spawner.cs
+++ b/Pixhell/Assets/Scripts/Combat/Spawners/Spawner.cs
@@ -85,9 +85,13 @@ public class Spawner : MonoBehaviour
         float timeToSpawn = float.Parse(parts[3]);
         float delay = float.Parse(parts[4]);
         yield return new WaitForSeconds(delay);
-        for (int i = 0; i < count; i++) {
+
+        // Fence Post: Spawn an enemy, then enter the waiting lool
+        // 3 enemies spawn: spawn, wait, spawn, wait, spawn
+        SpawnEnemy(enemyType);
+        for (int i = 0; i < count-1; i++) {
+            yield return new WaitForSeconds(timeToSpawn / (count - 1));
             SpawnEnemy(enemyType);
-            yield return new WaitForSeconds(timeToSpawn / count);
         }
         spawnersRunning -= 1;
     }


### PR DESCRIPTION
Wave spawner math now properly spawns enemies based on the timer and doesn't leave empty time. 